### PR TITLE
perf: reduce cloning operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,10 @@ serde = "1.0.126"
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
-serde_derive = "1.0.115"
-serde_json = "1.0.57"
+serde_derive      = "1.0.115"
+serde_json        = "1.0.57"
+criterion         = {  version = "0.5.1", features = ["html_reports"] }
+
+[[bench]]
+name = "parser"
+harness = false

--- a/benches/parser.rs
+++ b/benches/parser.rs
@@ -1,0 +1,16 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use node_semver::{Range, Version};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("range", |b| {
+        b.iter(|| {
+            let range = Range::parse(black_box(">=1.2.3-rc.4")).unwrap();
+            let version = Version::parse(black_box("1.2.3")).unwrap();
+
+            let _r = range.satisfies(black_box(&version));
+        })
+    });
+}
+
+criterion_group!(bench, criterion_benchmark);
+criterion_main!(bench);

--- a/src/range.rs
+++ b/src/range.rs
@@ -214,11 +214,11 @@ enum Predicate {
 }
 
 impl Predicate {
-    fn flip(&self) -> Self {
+    fn flip(self) -> Self {
         use Predicate::*;
         match self {
-            Excluding(v) => Including(v.clone()),
-            Including(v) => Excluding(v.clone()),
+            Excluding(v) => Including(v),
+            Including(v) => Excluding(v),
             Unbounded => Unbounded,
         }
     }
@@ -239,12 +239,12 @@ impl Bound {
         Bound::Lower(Predicate::Unbounded)
     }
 
-    fn predicate(&self) -> Predicate {
+    fn predicate(self) -> Predicate {
         use Bound::*;
 
         match self {
-            Lower(p) => p.clone(),
-            Upper(p) => p.clone(),
+            Lower(p) => p,
+            Upper(p) => p,
         }
     }
 }


### PR DESCRIPTION
### Benchmarks: 

#### Before:
```
range                   time:   [633.57 ns 634.84 ns 636.11 ns]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
```

#### After:
```
range                   time:   [614.54 ns 615.52 ns 616.51 ns]
                        change: [-4.0570% -2.8459% -1.6207%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
```