### PR TITLE
chore: upgrade miette

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 __bench = ["dep:criterion"]
 
 [dependencies]
-miette = "5.3.0"
+miette = "7.5.0"
 nom = "7.1.1"
 thiserror = "1.0.30"
 bytecount = "0.6.0"


### PR DESCRIPTION
Hi, we're using `node-semver` in [Turborepo](http://github.com/vercel/turborepo) (thanks for the crate!), and we're upgrading our miette version. We're running into some issues with having multiple versions of `miette` in our dependency tree, so I decided to bump the version in `node-semver` too. Any chance I could upstream this change? 