### PR TITLE
feat: make `miette` a default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,12 @@ edition = "2018"
 rust-version = "1.70.0"
 
 [features]
+default = ["miette"]
 __bench = ["dep:criterion"]
+miette = ["dep:miette"]
 
 [dependencies]
-miette = "7.5.0"
+miette = { version = "7.5.0", optional = true }
 nom = "7.1.1"
 thiserror = "1.0.30"
 bytecount = "0.6.0"

--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ assert!(version.satisfies(&range));
 ## Minimum Suggested Rust Version (MSRV)
 
 You must be 1.70.0 or taller to get on this ride.
+
+## Features
+
+By default, the crate uses [`miette`](https://docs.rs/miette) when errors are printed on the terminal.
+
+If you don't require this feature, you can set `default-features = false` in your `Cargo.toml`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ use std::cmp::{self, Ordering};
 use std::fmt;
 use std::num::ParseIntError;
 
-use miette::{Diagnostic, SourceSpan};
 use serde::{
     de::{self, Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},
@@ -44,11 +43,13 @@ a more specific [SemverErrorKind].
 #[error("{kind}")]
 pub struct SemverError {
     input: String,
-    span: SourceSpan,
+    #[cfg(feature = "miette")]
+    span: miette::SourceSpan,
     kind: SemverErrorKind,
 }
 
-impl Diagnostic for SemverError {
+#[cfg(feature = "miette")]
+impl miette::Diagnostic for SemverError {
     fn code<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
         self.kind().code()
     }
@@ -83,7 +84,8 @@ impl SemverError {
     }
 
     /// Returns the SourceSpan of the error.
-    pub fn span(&self) -> &SourceSpan {
+    #[cfg(feature = "miette")]
+    pub fn span(&self) -> &miette::SourceSpan {
         &self.span
     }
 
@@ -135,7 +137,8 @@ impl SemverError {
 /**
 The specific kind of error that occurred. Usually wrapped in a [SemverError].
 */
-#[derive(Debug, Clone, Error, Eq, PartialEq, Diagnostic)]
+#[derive(Debug, Clone, Error, Eq, PartialEq)]
+#[cfg_attr(feature = "miette", derive(miette::Diagnostic))]
 pub enum SemverErrorKind {
     /**
     Semver strings overall can't be longer than [MAX_LENGTH]. This is a


### PR DESCRIPTION
Closes #18 

This PR makes `miette` a default feature, so it can be turn off when it's not needed.

I also updated the README.md